### PR TITLE
add version check for collections vs collections.abc

### DIFF
--- a/json_converter/json_mapper.py
+++ b/json_converter/json_mapper.py
@@ -1,5 +1,10 @@
 import copy
-from collections import Mapping
+import sys
+
+if sys.version_info.minor >= 3:
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
 
 from .data_node import DataNode
 


### PR DESCRIPTION
The current version of the package produces a deprecation warning during import. This version changes the import based on the minor version of python to pull from the correct module

Partial `pyest` output for Python 3.8.1 before change. This warning does not appear after the change.
```
=============================================================================== warnings summary ================================================================================
json_converter/json_mapper.py:6
  /home/adam.hoelscher/Projects/json-converter/json_converter/json_mapper.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```